### PR TITLE
Forwarding line number when coerced data raise error

### DIFF
--- a/lib/estratto/data/base.rb
+++ b/lib/estratto/data/base.rb
@@ -13,7 +13,6 @@ module Estratto
       def coerce
         raise TypeCoercionNotFound
       end
-
     end
   end
 end

--- a/lib/estratto/data/coercer.rb
+++ b/lib/estratto/data/coercer.rb
@@ -28,7 +28,7 @@ module Estratto
       def target_coercer
         Object.const_get("Estratto::Data::#{type}").new(data, formats)
       rescue NameError
-        raise InvalidCoercionType
+        raise InvalidCoercionType, "Does not exists coercer class for #{type}"
       end
     end
   end

--- a/lib/estratto/data/coercer.rb
+++ b/lib/estratto/data/coercer.rb
@@ -7,18 +7,22 @@ require_relative 'string'
 module Estratto
   module Data
     class InvalidCoercionType < StandardError; end
-
+    class DataCoercionError < StandardError; end
     class Coercer
-      attr_reader :data, :type, :formats
+      attr_reader :data, :index, :type, :formats
 
-      def initialize(data:, type: 'String', formats: {})
+      def initialize(data:, index:, type: 'String', formats: {})
         @data = data
+        @index = index
         @type = type
         @formats = formats
       end
 
       def build
         target_coercer.coerce
+      rescue StandardError => error
+        raise DataCoercionError,
+              "Error when coercing #{data} on line #{index}, raising: #{error.message}"
       end
 
       def target_coercer

--- a/lib/estratto/parser.rb
+++ b/lib/estratto/parser.rb
@@ -11,10 +11,10 @@ module Estratto
     end
 
     def perform
-      @data ||= raw_content.map do |line|
+      @data ||= raw_content.map.with_index do |line, index|
         register_layout = layout.register_fields_for(line[layout.prefix_range])
         next if register_layout.nil?
-        Register.new(line, register_layout).refine
+        Register.new(line, index, register_layout).refine
       end.compact
     end
 

--- a/lib/estratto/register.rb
+++ b/lib/estratto/register.rb
@@ -3,10 +3,11 @@ require_relative 'helpers/range'
 
 module Estratto
   class Register
-    attr_reader :line, :register_layout
+    attr_reader :line, :index, :register_layout
 
-    def initialize(line, register_layout)
+    def initialize(line, index, register_layout)
       @line = line
+      @index = index
       @register_layout = register_layout
     end
 
@@ -22,6 +23,7 @@ module Estratto
 
     def coerced_data(range, type, formats)
       Estratto::Data::Coercer.new(
+        index: index,
         data: line[Estratto::Helpers::Range.for(range)],
         type: type,
         formats: formats || {}

--- a/spec/lib/estratto/data/coercer_spec.rb
+++ b/spec/lib/estratto/data/coercer_spec.rb
@@ -1,12 +1,26 @@
 RSpec.describe Estratto::Data::Coercer do
-  subject { described_class.new(data: data, type: type, formats: formats) }
+  subject { described_class.new(data: data, index: index, type: type, formats: formats) }
   let(:data) { 'STAR PLATINUM' }
+  let(:index) { 1 }
   let(:type) { 'String' }
   let(:formats) { {} }
 
   describe '#build' do
-    it do
-      expect(subject.build).to eq('STAR PLATINUM')
+    context 'valid coercion build' do
+      it do
+        expect(subject.build).to eq('STAR PLATINUM')
+      end
+    end
+
+    context 'invalid coercion build' do
+      let(:data) { '20190910' }
+      let(:type) { 'Date' }
+      it do
+        expect{ subject.build }.to raise_error(
+          Estratto::Data::DataCoercionError,
+          'Error when coercing 20190910 on line 1, raising: invalid date'
+        )
+      end
     end
   end
 

--- a/spec/lib/estratto/data/coercer_spec.rb
+++ b/spec/lib/estratto/data/coercer_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe Estratto::Data::Coercer do
         )
       end
     end
+
+    context 'invalid coercion type' do
+      let(:data) { '0xC' }
+      let(:type) { 'Octal' }
+      it do
+        expect{ subject.build }.to raise_error(
+          Estratto::Data::DataCoercionError,
+          'Error when coercing 0xC on line 1, raising: Does not exists coercer class for Octal'
+        )
+      end
+    end
   end
 
   describe '#target_coercer' do

--- a/spec/lib/estratto/register_spec.rb
+++ b/spec/lib/estratto/register_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Estratto::Register do
-  subject { described_class.new(line, layout) }
+  subject { described_class.new(line, index, layout) }
   let(:line) { '42FIREFOX    57192     0.6' }
 
   let(:layout) do
@@ -9,6 +9,8 @@ RSpec.describe Estratto::Register do
       { 'name' => 'acceptance', 'range' => '18..25', 'type' => 'Float' }
     ]
   end
+
+  let(:index) { 1 }
 
   describe '#refine' do
     it do


### PR DESCRIPTION
refs to #9 

Implement forwarder logic to line index, for error identification purposes. In this way, the error can be solved way more faster than actually did.

Error template:
```
Error when coercing 0xC on line 1, raising: Does not exists coercer class for Octal
```